### PR TITLE
Add new command epc:pop-to-last-server-process-buffer

### DIFF
--- a/epc.el
+++ b/epc.el
@@ -292,7 +292,9 @@ failure."
           (setq port (string-to-number port-str)
                 cont nil))
          ((< 0 (length port-str))
-          (error "Server may raise an error : %s" port-str))
+          (error "Server may raise an error. \
+Use \"M-x epc:pop-to-last-server-process-buffer RET\" \
+to see full traceback:\n%s" port-str))
          ((not (eq 'run (process-status process)))
           (setq cont nil))
          (t


### PR DESCRIPTION
EPC のサーバープロセスのスタートに失敗した場合、そのエラーメッセージを表示するための関数を追加しました。サーバー側の EPC モジュールのインストールに失敗していた場合など、troubleshootingに役立つと思います。

epc:controller で統一的に管理できれば素敵ですが、コネクションが確立して manager オブジェクトがある前提でかかれているようなので、大規模な修正が必要になると思いました。このパッチは当面の対策としては悪くないと思いますが、どうでしょう。
