### PR TITLE
Set process-query-on-exit-flag to nil

### DIFF
--- a/epc.el
+++ b/epc.el
@@ -111,6 +111,7 @@ return epc:connection object."
     (set-process-sentinel connection-process
                           (lambda (p e) 
                             (epc:process-sentinel connection p e)))
+    (set-process-query-on-exit-flag connection-process nil)
     connection))
 
 (defun epc:connection-reset (connection)
@@ -301,6 +302,7 @@ to see full traceback:\n%s" port-str))
           (incf cont)
           (when (< 30 cont) ; timeout 3 seconds
             (error "Timeout server response."))))))
+    (set-process-query-on-exit-flag process nil)
     (make-epc:manager :server-process process
                       :commands (cons server-prog server-args)
                       :title (mapconcat 'identity (cons server-prog server-args) " ")


### PR DESCRIPTION
EPC 関連のプロセスを閉じる時にユーザーに通知しないようにしてみました。 例えば、 C-x C-c した時に、 EPC のプロセスが残っていても Emacs の終了を妨害しなくなります。 ユーザー的には、 EPC が始めたプロセスについて聞かれてもどうすれば良いか分からないと思うので、デフォルトとしてはこっちが良いんじゃないかと思います。もし何か teardown する必要があれば、それは EPC を使っているライブラリの仕事じゃないでしょうか。
