### PR TITLE
Fix byte compile warnings

### DIFF
--- a/epc.el
+++ b/epc.el
@@ -45,6 +45,8 @@
 (defvar epc:debug-out nil)
 (defvar epc:debug-buffer "*epc log*")
 
+(defvar epc:mngr)
+
 ;;(setq epc:debug-out t)
 ;;(setq epc:debug-out nil)
 
@@ -856,7 +858,7 @@ Restart process."
           (deferred:nextc it
             (lambda (ret) (message "Result : %S" ret)))
           (deferred:error it
-            (lambda (err) (message "Error : %S" ret))))))))
+            (lambda (err) (message "Error : %S" err))))))))
 
 (defun epc:define-keymap (keymap-list &optional prefix)
   "[internal] Keymap utility."


### PR DESCRIPTION
I got following error when `epc.el` is byte-compiled.

```
In epc:controller-methods-update-buffer:
epc.el:843:34:Warning: assignment to free variable `epc:mngr'

In epc:controller-methods-eval-command:
epc.el:855:30:Warning: reference to free variable `epc:mngr'
epc.el:859:49:Warning: reference to free variable `ret'
```
