### PR TITLE
Ignore [ \n\r] around port number

### DIFF
--- a/epc.el
+++ b/epc.el
@@ -394,7 +394,7 @@ failure."
       (let ((port-str (with-current-buffer process-buffer
                           (buffer-string))))
         (cond
-         ((string-match "^[0-9]+$" port-str)
+         ((string-match "^[ \n\r]*[0-9]+[ \n\r]*$" port-str)
           (setq port (string-to-number port-str)
                 cont nil))
          ((< 0 (length port-str))


### PR DESCRIPTION
In windows, it seems that sometimes Python script puts newline _before_
anything is printed.  It can be solved in epc.el side with reasonably
easy change in regexp.

See: https://github.com/tkf/emacs-jedi/issues/148#issuecomment-38296759

---

Re: #17, it might be reasonable to _not_ pull this patch.  But you can save me from debugging in Windows (I don't even have one) by pulling this (´・ω・`).
