### PR TITLE
Remove taint mode flag for suppressing warnings

### DIFF
--- a/RPC-EPC/t/perlcritic.t
+++ b/RPC-EPC/t/perlcritic.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl
 
 use Test::More;
 eval "use Test::Perl::Critic";


### PR DESCRIPTION
This is passed however I got following warnings.

```
% prove -bv t/perlcritic.t
t/perlcritic.t .. Couldn't require Perl::Critic::Policy::Documentation::PodSpelling : Insecure dependency in `` while running with -T switch at /home/syohei/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/File/HomeDir/FreeDesktop.pm line 32.
Compilation failed in require at /home/syohei/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/Pod/Spell.pm line 10.
BEGIN failed--compilation aborted at /home/syohei/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/Pod/Spell.pm line 10.
Compilation failed in require at /home/syohei/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/Perl/Critic/Policy/Documentation/PodSpelling.pm line 21.
BEGIN failed--compilation aborted at /home/syohei/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/Perl/Critic/Policy/Documentation/PodSpelling.pm line 21.
Compilation failed in require at (eval 82) line 2.
 at /home/syohei/.plenv/versions/5.18.2/lib/perl5/site_perl/5.18.2/Module/Pluggable.pm line 32.

1..1
ok 1 - Test::Perl::Critic for "blib/lib/RPC/EPC/Service.pm"
ok
```
